### PR TITLE
[FIX] 고수 가입시 is_main값 true로 수정

### DIFF
--- a/models/MasterDao.js
+++ b/models/MasterDao.js
@@ -91,7 +91,7 @@ const insertMasterCat = async (masterID, lessonCatID) => {
     await prisma.$queryRaw`
         INSERT INTO masters_categories (master_id, lesson_category_id, is_main)
         VALUES
-        (${masterID}, ${Number(catID)}, false);
+        (${masterID}, ${Number(catID)}, true);
     `;
   });
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 고수 가입시에는 메인 서비스를 true값으로 줘야 해서 수정했습니다.

<br />

## :: 구현 사항 설명
1. 마스터 가입 로직 수정
- MasterDao에서 함수 수정

<br />

## :: 성장 포인트 
- 데이터베이스에 대해 더 자세히 공부할 수 있었습니다.

<br />
