### PR TITLE
[FIX] 고수 회원가입 함수 분리 및 리팩토링

### DIFF
--- a/controllers/MasterController.js
+++ b/controllers/MasterController.js
@@ -53,7 +53,7 @@ const signUpDirect = async (req, res, next) => {
 
     return res.status(201).json({ message: "SIGNUP_SUCCESS" });
   } catch (error) {
-    return res.status(500).json({ message: error.message });
+    return res.status(500).json({ message: "SERVER_ERROR" });
   }
 };
 
@@ -92,7 +92,7 @@ const signUp = async (req, res, next) => {
 
     return res.status(201).json({ message: "SIGNUP_SUCCESS" });
   } catch (error) {
-    return res.status(500).json({ message: error.message });
+    return res.status(500).json({ message: "SERVER_ERROR" });
   }
 };
 

--- a/models/MasterDao.js
+++ b/models/MasterDao.js
@@ -1,4 +1,5 @@
 const { PrismaClient } = require("@prisma/client");
+const { use } = require("../routes/MasterRoute");
 
 const prisma = new PrismaClient();
 
@@ -85,7 +86,7 @@ const createMaster = async (userID, name, addressID, detailAddressID) => {
   });
 };
 
-const insertMasterCat = async (masterID, lessonCatID) => {
+const makeMasterMainCategories = async (masterID, lessonCatID) => {
   console.log(lessonCatID);
   return lessonCatID.map(async (catID) => {
     await prisma.$queryRaw`
@@ -207,11 +208,76 @@ const isMaster = async (masterID) => {
   `;
 };
 
+const createUserDirectMaster = async (
+  inputName,
+  inputEmail,
+  inputPW,
+  inputPhone
+) => {
+  return await prisma.users.create({
+    data: {
+      name: inputName,
+      email: inputEmail,
+      password: inputPW,
+      phone_number: inputPhone,
+    },
+  });
+};
+
+const upgradeUserStatus = async (userID, inputPhone) => {
+  return await prisma.$queryRaw`
+    UPDATE users SET phone_number = ${inputPhone}
+    WHERE id = ${userID};
+  `;
+};
+
+const findUserInfo = async (inputEmail, inputPhone) => {
+  return await prisma.$queryRaw`
+    SELECT id, name
+    FROM users
+    WHERE users.email = ${inputEmail} 
+    OR users.phone_number = ${inputPhone};
+  `;
+};
+
+const findUserName = async (userId) => {
+  return await prisma.$queryRaw`
+    SELECT name
+    FROM users
+    WHERE id = ${userId};
+  `
+}
+
+const getUserByEmail = async (email) => {
+  return await prisma.$queryRaw`
+    select id, password from users where email= ${email};`;
+};
+
+const crossCheckAddress = async (detailAddress) => {
+  return await prisma.$queryRaw`
+    SELECT address_id 
+    FROM detail_address
+    WHERE id = ${detailAddress};
+  `
+}
+
+const rollBackSignUp = async (userId) => {
+  return await prisma.$queryRaw`
+    DELETE FROM users WHERE id = ${userId};
+  `
+}
+
+const rollBackUserStatus = async (userId) => {
+  return await prisma.$queryRaw`
+    UPDATE users SET phone_number = null WHERE id = ${userId};
+  `
+}
+
 module.exports = {
   getMasters,
   findMasterInfo,
   createMaster,
-  insertMasterCat,
+  makeMasterMainCategories,
   findMasterAddress,
   sendMasterDetail,
   getMasterProfile,
@@ -219,4 +285,12 @@ module.exports = {
   getMasterByUserId,
   getMastersByCategory,
   isMaster,
+  createUserDirectMaster,
+  upgradeUserStatus,
+  findUserInfo,
+  findUserName,
+  getUserByEmail,
+  crossCheckAddress,
+  rollBackSignUp,
+  rollBackUserStatus
 };

--- a/models/UserDao.js
+++ b/models/UserDao.js
@@ -1,40 +1,6 @@
 const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
-const findUserInfo = async (inputEmail, inputPhone) => {
-  return await prisma.$queryRaw`
-    SELECT id, name, email, user_image AS userImg, phone_number AS phoneNumber, is_deleted AS isDeleted 
-    FROM users
-    WHERE users.email = ${inputEmail} 
-    OR users.phone_number = ${inputPhone};
-  `;
-};
-
-const createUserDirectMaster = async (
-  inputName,
-  inputEmail,
-  inputPW,
-  inputPhone
-) => {
-  return await prisma.users.create({
-    data: {
-      name: inputName,
-      email: inputEmail,
-      password: inputPW,
-      phone_number: inputPhone,
-    },
-  });
-};
-
-const insertPhoneNum = async (userID, inputPhone) => {
-  return await prisma.$queryRaw`
-    INSERT INTO users (phone_number)
-    VALUES
-    (${inputPhone})
-    WHERE id = ${userID};
-  `;
-};
-
 const sendLogIn = async (email) => {
   return await prisma.$queryRaw`
   select id,email,password from users 
@@ -66,9 +32,6 @@ const getUserByUserId = async (userId) => {
 };
 
 module.exports = {
-  findUserInfo,
-  insertPhoneNum,
-  createUserDirectMaster,
   sendLogIn,
   getUserByEmail,
   createUser,

--- a/routes/ImageRoute.js
+++ b/routes/ImageRoute.js
@@ -5,8 +5,7 @@ const validateToken = require("../middleware/userValidateToken");
 const ImageController = require("../controllers/ImageController");
 
 // POST
-// router.post("/:masterId/:reviewId",validateToken, ImageController.uploadReviewImage);
-router.post("/:masterId/:reviewId", ImageController.uploadReviewImage);
+router.post("/:reviewId", validateToken, ImageController.uploadReviewImage);
 
 
 module.exports = router;

--- a/routes/MasterRoute.js
+++ b/routes/MasterRoute.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const MasterController = require("../controllers/MasterController");
 
 const masterValidateToken = require("../middleware/masterValidateToken");
+const userValidateToken = require("../middleware/userValidateToken");
 
 // GET
 router.get("/profile", masterValidateToken, MasterController.getMasterProfile);
@@ -12,7 +13,8 @@ router.get("/main_list/:category", MasterController.getMastersByCategory);
 router.get("/users/:id", MasterController.sendMasterDetail);
 
 // POST
-router.post("/signup", MasterController.signUp);
+router.post("/signup", userValidateToken, MasterController.signUp);
+router.post("/signupdirect", MasterController.signUpDirect);
 
 // PUT
 router.put("/profile", MasterController.setMasterProfile);


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [X] 리뷰 반영
- [X] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 고수 회원가입 함수를 로그인한 경우/ 안한 경우로 분리하고 리팩토링했습니다.

<br />

## :: 구현 사항 설명
1.  고수 회원가입 함수 리팩토링
 -  로그인시 고수 가입 함수는 signUpDirect로 분리 및 토큰에서 userId 가져오는 방향으로 수정
 - 보안문제로 response에 userId, masterId 반환하는 부분 제거
 - 주소와 상세 주소가 연결되지 않으면 오류 반환 & 진행하던 테이블에 내용 제거하는 로직 추가
 - UserDao의 일부 함수 MasterDao로 이동


<br />

## :: 성장 포인트
- 로그인을 하고 가입 시도를 하는지 로그인을 안하고 가입 시도를 하는지에 따라 기능이 다르고 분리를 해야한다는 점을 알게됐습니다.
- 회원가입후 반환값으로 userId, masterId를 반환했는데 보안상 문제가 있을 수 있다는 점을 피드백 받아 수정했습니다.
- 가입 진행중 오류 메시지로 반환하면 DB에 입력하던 과정은 그대로 남게 되어 다시 가입시도할때 문제가 생기기 때문에 제거하는 함수를 추가했습니다.
- 미들웨어를 두 가지로 나누어서 일반 회원, 고수의 토큰을 검증하면 로그인시 id값 하나만 토큰으로 만들어도 서버에서 적절한 미들웨어를 적용하면 두 가지 이상의 회원 종류가 나뉘어도 대응할 수 있다는 점을 알게 됐습니다.

<br />
